### PR TITLE
Fix helm argocd wait job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: pre-commit
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:
@@ -18,32 +21,32 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        cache: pip
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
 
-    - name: Install Python dependencies
-      run: pip install -r requirements.txt
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
 
-    - name: Install terraform-docs
-      uses: jaxxstorm/action-install-gh-release@v1.9.0
-      with:
-        repo: terraform-docs/terraform-docs
-        tag: ${{ env.TERRAFORM_DOCS_VERSION }}
-        cache: enable
+      - name: Install terraform-docs
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
+        with:
+          repo: terraform-docs/terraform-docs
+          tag: ${{ env.TERRAFORM_DOCS_VERSION }}
+          cache: enable
 
-    - name: TFLint cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.tflint.d/plugins
-        key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+      - name: TFLint cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.tflint.d/plugins
+          key: ${{ runner.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
 
-    - name: Install TFLint
-      uses: terraform-linters/setup-tflint@v2
-      with:
-        tflint_version: ${{ env.TFLINT_VERSION }}
+      - name: Install TFLint
+        uses: terraform-linters/setup-tflint@v2
+        with:
+          tflint_version: ${{ env.TFLINT_VERSION }}
 
-    - name: Run pre-commit
-      uses: pre-commit/action@v3.0.0
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,5 +1,8 @@
 name: Terraform validate
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:

--- a/argo-helm.tf
+++ b/argo-helm.tf
@@ -91,16 +91,15 @@ resource "kubernetes_job" "helm_argo_application_wait" {
   count = local.helm_argo_application_wait_enabled ? 1 : 0
 
   metadata {
-    name        = "${var.helm_release_name}-argo-application-wait"
-    namespace   = var.argo_namespace
-    labels      = local.argo_application_metadata.labels
-    annotations = local.argo_application_metadata.annotations
+    generate_name = "${var.helm_release_name}-argo-application-wait"
+    namespace     = var.argo_namespace
+    labels        = local.argo_application_metadata.labels
+    annotations   = local.argo_application_metadata.annotations
   }
 
   spec {
     template {
       metadata {
-        name        = "${var.helm_release_name}-argo-application-wait"
         labels      = local.argo_application_metadata.labels
         annotations = local.argo_application_metadata.annotations
       }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -22,7 +22,7 @@ The code in this example shows how to use the module with basic configuration an
 | <a name="module_addon_installation_helm"></a> [addon\_installation\_helm](#module\_addon\_installation\_helm) | ../../ | n/a |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 2.3.0 |
 | <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 2.4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.14.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 4.0.0 |
 
 ## Resources
 

--- a/examples/basic/base.tf
+++ b/examples/basic/base.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
+  version = "4.0.0"
 
   name               = "cluster-autoscaler-vpc"
   cidr               = "10.0.0.0/16"


### PR DESCRIPTION
# Description
There are issues with `kubernetes_job` when terraform wants to perform recreate operation `create_before_destroy` (create replacement and then destroy) on kubernetes_job. `helm_argo_application_wait `job is using the statically defined name and in such situations terraform will fail with error API error: jobs.batch "cilium-argo-application-wait" already exists. This fix introduces `generated_name` for all active kubernetes jobs instead of using a statically defined job name, where generated_name is prefix, used by the server, to generate a unique name; this value will also be combined with a unique suffix.

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

