### PR TITLE
fix(cilium): fix namespace to use kube-system by def

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@
 
 locals {
   addon = {
-    name = "cilium"
+    name      = "cilium"
+    namespace = "kube-system"
 
     helm_chart_version = "1.15.8"
     helm_repo_url      = "https://helm.cilium.io"


### PR DESCRIPTION
# Description
Namespace by defeault reffer to addon.name but we need  kube-system.
Fixing default value.

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
In sandbox1 loaded local module
